### PR TITLE
chore(packages): Update required Node.js to `>=18` & use shared `tsup` config

### DIFF
--- a/.changeset/nasty-hats-change.md
+++ b/.changeset/nasty-hats-change.md
@@ -1,0 +1,10 @@
+---
+"@adchitects/eslint-config": minor
+"@adchitects/markdownlint-config": minor
+"@adchitects/prettier-config": minor
+"@adchitects/stylelint-config": minor
+"@adchitects/syncpack-config": minor
+"@adchitects/typescript-config": minor
+---
+
+🏗️ Set required Node.js version to `>=18`

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -18,7 +18,7 @@
 	"repository": "https://github.com/adchitects/configs/tree/main/packages/eslint",
 	"bugs": "https://github.com/adchitects/configs/issues",
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"main": "dist/index.js",
 	"files": [

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -71,6 +71,7 @@
 		"eslint-plugin-yml": "1.2.0"
 	},
 	"devDependencies": {
+		"@adchitects/tsup-config": "workspace:*",
 		"@adchitects/typescript-config": "workspace:*",
 		"@types/eslint": "8.4.6",
 		"@types/node": "18.11.9",

--- a/packages/eslint/tsup.config.ts
+++ b/packages/eslint/tsup.config.ts
@@ -1,12 +1,11 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-	clean: true,
+import { getNodeCJSOptions } from "@adchitects/tsup-config";
+
+export default defineConfig((options) => ({
+	...getNodeCJSOptions(options),
+	bundle: true,
+	dts: false,
 	entry: ["source/index.ts"],
-	format: ["cjs"],
-	minify: true,
 	noExternal: ["@workspace/shared"],
-	sourcemap: true,
-	splitting: false,
-	target: ["node16"],
-});
+}));

--- a/packages/markdownlint/package.json
+++ b/packages/markdownlint/package.json
@@ -18,7 +18,7 @@
 	"repository": "https://github.com/adchitects/configs/tree/main/packages/markdownlint",
 	"bugs": "https://github.com/adchitects/configs/issues",
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"main": "dist/index.json",
 	"files": [

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -18,7 +18,7 @@
 	"repository": "https://github.com/adchitects/configs/tree/main/packages/prettier",
 	"bugs": "https://github.com/adchitects/configs/issues",
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"main": "dist/index.js",
 	"files": [

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -47,6 +47,7 @@
 		"@prettier/plugin-php": "0.19.1"
 	},
 	"devDependencies": {
+		"@adchitects/tsup-config": "workspace:*",
 		"@adchitects/typescript-config": "workspace:*",
 		"@types/node": "18.11.9",
 		"@types/prettier": "2.7.1",

--- a/packages/prettier/tsup.config.ts
+++ b/packages/prettier/tsup.config.ts
@@ -1,12 +1,9 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-	clean: true,
-	entry: ["source/index.ts"],
-	format: ["cjs"],
-	minify: true,
+import { getNodeCJSOptions } from "@adchitects/tsup-config";
+
+export default defineConfig((options) => ({
+	...getNodeCJSOptions(options),
+	entry: ["source/**/*.ts"],
 	noExternal: ["@workspace/shared"],
-	sourcemap: true,
-	splitting: false,
-	target: ["node16"],
-});
+}));

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -18,7 +18,7 @@
 	"repository": "https://github.com/adchitects/configs/tree/main/packages/stylelint",
 	"bugs": "https://github.com/adchitects/configs/issues",
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"main": "dist/index.js",
 	"files": [

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -53,6 +53,7 @@
 		"stylelint-scss": "4.3.0"
 	},
 	"devDependencies": {
+		"@adchitects/tsup-config": "workspace:*",
 		"@adchitects/typescript-config": "workspace:*",
 		"@types/node": "18.11.9",
 		"@workspace/shared": "workspace:*",

--- a/packages/stylelint/tsup.config.ts
+++ b/packages/stylelint/tsup.config.ts
@@ -1,12 +1,9 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-	clean: true,
-	entry: ["source/index.ts"],
-	format: ["cjs"],
-	minify: true,
+import { getNodeCJSOptions } from "@adchitects/tsup-config";
+
+export default defineConfig((options) => ({
+	...getNodeCJSOptions(options),
+	entry: ["source/**/*.ts"],
 	noExternal: ["@workspace/shared"],
-	sourcemap: true,
-	splitting: false,
-	target: ["node16"],
-});
+}));

--- a/packages/syncpack/package.json
+++ b/packages/syncpack/package.json
@@ -44,6 +44,7 @@
 		"syncpack": "8.3.9"
 	},
 	"devDependencies": {
+		"@adchitects/tsup-config": "workspace:*",
 		"@adchitects/typescript-config": "workspace:*",
 		"@types/node": "18.11.9",
 		"@workspace/shared": "workspace:*",

--- a/packages/syncpack/package.json
+++ b/packages/syncpack/package.json
@@ -18,7 +18,7 @@
 	"repository": "https://github.com/adchitects/configs/tree/main/packages/syncpack",
 	"bugs": "https://github.com/adchitects/configs/issues",
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"main": "dist/index.js",
 	"files": [

--- a/packages/syncpack/tsup.config.ts
+++ b/packages/syncpack/tsup.config.ts
@@ -1,12 +1,9 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-	clean: true,
-	entry: ["source/index.ts"],
-	format: ["cjs"],
-	minify: true,
+import { getNodeCJSOptions } from "@adchitects/tsup-config";
+
+export default defineConfig((options) => ({
+	...getNodeCJSOptions(options),
+	entry: ["source/**/*.ts"],
 	noExternal: ["@workspace/shared"],
-	sourcemap: true,
-	splitting: false,
-	target: ["node16"],
-});
+}));

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -18,7 +18,7 @@
 	"repository": "https://github.com/adchitects/configs/tree/main/packages/typescript",
 	"bugs": "https://github.com/adchitects/configs/issues",
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"main": "tsconfig.json",
 	"files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,7 @@ importers:
 
   shared:
     specifiers:
+      '@adchitects/tsup-config': workspace:*
       '@adchitects/typescript-config': workspace:*
       '@types/node': 18.11.9
       deepmerge-ts: 4.2.2
@@ -241,6 +242,7 @@ importers:
       deepmerge-ts: 4.2.2
       read-pkg-up: 9.1.0
     devDependencies:
+      '@adchitects/tsup-config': link:../packages/tsup
       '@adchitects/typescript-config': link:../packages/typescript
       '@types/node': 18.11.9
       tsup: 6.4.0_typescript@4.8.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,7 @@ importers:
 
   packages/eslint:
     specifiers:
+      '@adchitects/tsup-config': workspace:*
       '@adchitects/typescript-config': workspace:*
       '@rushstack/eslint-patch': 1.2.0
       '@types/eslint': 8.4.6
@@ -120,6 +121,7 @@ importers:
       eslint-plugin-unicorn: 43.0.2
       eslint-plugin-yml: 1.2.0
     devDependencies:
+      '@adchitects/tsup-config': link:../tsup
       '@adchitects/typescript-config': link:../typescript
       '@types/eslint': 8.4.6
       '@types/node': 18.11.9
@@ -141,6 +143,7 @@ importers:
 
   packages/prettier:
     specifiers:
+      '@adchitects/tsup-config': workspace:*
       '@adchitects/typescript-config': workspace:*
       '@prettier/plugin-php': 0.19.1
       '@types/node': 18.11.9
@@ -151,6 +154,7 @@ importers:
     dependencies:
       '@prettier/plugin-php': 0.19.1
     devDependencies:
+      '@adchitects/tsup-config': link:../tsup
       '@adchitects/typescript-config': link:../typescript
       '@types/node': 18.11.9
       '@types/prettier': 2.7.1
@@ -160,6 +164,7 @@ importers:
 
   packages/stylelint:
     specifiers:
+      '@adchitects/tsup-config': workspace:*
       '@adchitects/typescript-config': workspace:*
       '@types/node': 18.11.9
       '@workspace/shared': workspace:*
@@ -182,6 +187,7 @@ importers:
       stylelint-order: 5.0.0_stylelint@14.14.1
       stylelint-scss: 4.3.0_stylelint@14.14.1
     devDependencies:
+      '@adchitects/tsup-config': link:../tsup
       '@adchitects/typescript-config': link:../typescript
       '@types/node': 18.11.9
       '@workspace/shared': link:../../shared
@@ -191,6 +197,7 @@ importers:
 
   packages/syncpack:
     specifiers:
+      '@adchitects/tsup-config': workspace:*
       '@adchitects/typescript-config': workspace:*
       '@types/node': 18.11.9
       '@workspace/shared': workspace:*
@@ -198,6 +205,7 @@ importers:
       tsup: 6.4.0
       typescript: 4.8.4
     devDependencies:
+      '@adchitects/tsup-config': link:../tsup
       '@adchitects/typescript-config': link:../typescript
       '@types/node': 18.11.9
       '@workspace/shared': link:../../shared

--- a/shared/package.json
+++ b/shared/package.json
@@ -5,7 +5,7 @@
 	"name": "@workspace/shared",
 	"version": "0.0.0",
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"exports": {
 		"./configuration": "./dist/configuration.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -41,6 +41,7 @@
 	},
 	"devDependencies": {
 		"@adchitects/typescript-config": "workspace:*",
+		"@adchitects/tsup-config": "workspace:*",
 		"@types/node": "18.11.9",
 		"tsup": "6.4.0",
 		"typescript": "4.8.4"

--- a/shared/package.json
+++ b/shared/package.json
@@ -7,18 +7,31 @@
 	"engines": {
 		"node": ">=18"
 	},
+	"files": [
+		"dist/"
+	],
 	"exports": {
 		"./configuration": {
 			"import": "./dist/configuration.js",
+			"require": "./dist/configuration.cjs",
 			"types": "./dist/configuration.d.ts"
 		},
 		"./environment": {
 			"import": "./dist/environment.js",
+			"require": "./dist/environment.cjs",
 			"types": "./dist/environment.d.ts"
 		},
 		"./module": {
 			"import": "./dist/module.js",
+			"require": "./dist/module.cjs",
 			"types": "./dist/module.d.ts"
+		}
+	},
+	"typesVersions": {
+		"*": {
+			"*": [
+				"./dist/*"
+			]
 		}
 	},
 	"scripts": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -8,15 +8,17 @@
 		"node": ">=18"
 	},
 	"exports": {
-		"./configuration": "./dist/configuration.js",
-		"./environment": "./dist/environment.js",
-		"./module": "./dist/module.js"
-	},
-	"typesVersions": {
-		"*": {
-			"*": [
-				"./dist/*"
-			]
+		"./configuration": {
+			"import": "./dist/configuration.js",
+			"types": "./dist/configuration.d.ts"
+		},
+		"./environment": {
+			"import": "./dist/environment.js",
+			"types": "./dist/environment.d.ts"
+		},
+		"./module": {
+			"import": "./dist/module.js",
+			"types": "./dist/module.d.ts"
 		}
 	},
 	"scripts": {

--- a/shared/tsup.config.ts
+++ b/shared/tsup.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from "tsup";
 
-import { getNodeESMOptions} from "@adchitects/tsup-config";
+import { getNodeUniveralOptions } from "@adchitects/tsup-config";
 
 export default defineConfig((options) => ({
-	...getNodeESMOptions(options),
+	...getNodeUniveralOptions(options),
 	entry: ["source/*.ts"],
 }));

--- a/shared/tsup.config.ts
+++ b/shared/tsup.config.ts
@@ -1,13 +1,8 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-	clean: true,
-	dts: true,
+import { getNodeESMOptions} from "@adchitects/tsup-config";
+
+export default defineConfig((options) => ({
+	...getNodeESMOptions(options),
 	entry: ["source/*.ts"],
-	format: ["esm"],
-	minify: true,
-	outDir: "dist/",
-	sourcemap: true,
-	splitting: true,
-	target: ["node16"],
-});
+}));


### PR DESCRIPTION
# What is the purpose of this Pull Request?

-   Update required Node.js to latest LTS version `v18` and apply it to the packages which haven't set it yet.
-   Improve `@workspace/shared` package
-   Use shared `@adchitects/tsup-config` for packages which uses it for building

## Type of this Pull Request

-   ⚙️ Workflow s adjustments
-   🔧 Configurations changes

---

## TODO

-   [x] Write release notes for packages @xeho91
-   [x] Change build systems for packages which uses `tsup` @xeho91
